### PR TITLE
Update gfwlist.pac

### DIFF
--- a/gfwlist.pac
+++ b/gfwlist.pac
@@ -1793,6 +1793,7 @@ var rules = [
             "gcmasia.com",
             "gcpnews.com",
             "gcr.io",
+            "gcu.edu.cn",
             "gdbt.net",
             "gdzf.org",
             "geek-art.net",


### PR DESCRIPTION
Add "gcu.edu.cn" for Guangzhou College of South China University of Technology.