### PR TITLE
Add some Proxys / CDNs address

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,10 @@
 Automatically convert gfwlist to pac everyday
 
 Just use https://raw.githubusercontent.com/petronny/gfwlist2pac/master/gfwlist.pac
+
+Proxys / CDNs:
+
+- jsDelivr: https://cdn.jsdelivr.net/gh/petronny/gfwlist2pac@master/gfwlist.pac
+- FastGit: https://raw.fastgit.org/petronny/gfwlist2pac/master/gfwlist.pac
+- GitHub Proxy: https://ghproxy.com/https://github.com/petronny/gfwlist2pac/blob/master/gfwlist.pac
+- 7ED SERVICE: https://raw.sevencdn.com/petronny/gfwlist2pac/master/gfwlist.pac


### PR DESCRIPTION
`raw.githubusercontent.com` 在国内访问太慢了，有时候直接访问不了。

在 README.md 中增加了几个指向 [`gfwlist.pac`](https://raw.githubusercontent.com/petronny/gfwlist2pac/master/gfwlist.pac) 的 Proxy / CDN 地址。